### PR TITLE
Add trailing "ends here" line for package.el compatibility

### DIFF
--- a/nimrod-mode.el
+++ b/nimrod-mode.el
@@ -445,3 +445,4 @@ On reaching column 0, it will cycle back to the maximum sensible indentation."
 
 (setq auto-mode-alist (cons '("\\.nim$" . nimrod-mode) auto-mode-alist))
 
+;;; nimrod-mode.el ends here


### PR DESCRIPTION
This small change allows the library to be installed using `package-install-file`, which requires the source file to be in the standardised format.
